### PR TITLE
PRED-1111: avoid structlog jsonlogs duplicates in sentry

### DIFF
--- a/logging_config/Pipfile
+++ b/logging_config/Pipfile
@@ -10,6 +10,7 @@ structlog = "*"
 buddy-config = "*"
 colorama = "*"
 pygments = "*"
+structlog-sentry = "*"
 
 [requires]
 python_version = "3.7"

--- a/logging_config/Pipfile.lock
+++ b/logging_config/Pipfile.lock
@@ -1,11 +1,7 @@
 {
     "_meta": {
         "hash": {
-<<<<<<< HEAD
             "sha256": "56895823b1ffc98c7f88128e31fd58fd8ff80effabdcd90422a3e873e17a008e"
-=======
-            "sha256": "0b38e58c2545846aa0ff8303a1d8cfa51dda9043978684bd82e080c348751ca3"
->>>>>>> ddd35c96a2cac14b5b79ec295be8ede7934af8c5
         },
         "pipfile-spec": 6,
         "requires": {
@@ -26,7 +22,6 @@
             ],
             "index": "pypi",
             "version": "==0.1.6"
-<<<<<<< HEAD
         },
         "certifi": {
             "hashes": [
@@ -34,8 +29,6 @@
                 "sha256:8fc0819f1f30ba15bdb34cceffb9ef04d99f420f68eb75d901e9560b8749fc41"
             ],
             "version": "==2020.6.20"
-=======
->>>>>>> ddd35c96a2cac14b5b79ec295be8ede7934af8c5
         },
         "colorama": {
             "hashes": [
@@ -65,7 +58,7 @@
                 "sha256:30639c035cdb23534cd4aa2dd52c3bf48f06e5f4a941509c8bafd8ce11080259",
                 "sha256:8b74bedcbbbaca38ff6d7491d76f2b06b3592611af620f8426e82dddb04a5ced"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2'",
             "version": "==1.15.0"
         },
         "structlog": {

--- a/logging_config/Pipfile.lock
+++ b/logging_config/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "ba356198ea5ee551a5a6f85770686929f1fde0118f1adb86fd83ac4b17d563a4"
+            "sha256": "56895823b1ffc98c7f88128e31fd58fd8ff80effabdcd90422a3e873e17a008e"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -18,10 +18,17 @@
     "default": {
         "buddy-config": {
             "hashes": [
-                "sha256:f923d554b05fd1eb55b301534237a764b3d8293ce3574801089b40463c8f0235"
+                "sha256:7ee24cc82d13b1c023a8b2788be50dd5f646ebc746b7c92ddc145acf5ecefb6b"
             ],
             "index": "pypi",
-            "version": "==0.1.5"
+            "version": "==0.1.6"
+        },
+        "certifi": {
+            "hashes": [
+                "sha256:5930595817496dd21bb8dc35dad090f1c2cd0adfaf21204bf6732ca5d8ee34d3",
+                "sha256:8fc0819f1f30ba15bdb34cceffb9ef04d99f420f68eb75d901e9560b8749fc41"
+            ],
+            "version": "==2020.6.20"
         },
         "colorama": {
             "hashes": [
@@ -39,6 +46,13 @@
             "index": "pypi",
             "version": "==2.6.1"
         },
+        "sentry-sdk": {
+            "hashes": [
+                "sha256:d359609e23ec9360b61e5ffdfa417e2f6bca281bfb869608c98c169c7e64acd5",
+                "sha256:e12eb1c2c01cd9e9cfe70608dbda4ef451f37ef0b7cbb92e5d43f87c341d6334"
+            ],
+            "version": "==0.16.5"
+        },
         "six": {
             "hashes": [
                 "sha256:30639c035cdb23534cd4aa2dd52c3bf48f06e5f4a941509c8bafd8ce11080259",
@@ -54,6 +68,22 @@
             ],
             "index": "pypi",
             "version": "==20.1.0"
+        },
+        "structlog-sentry": {
+            "hashes": [
+                "sha256:5afe21bf7bfa27284345198415ac6c88941d4aef345a523ae990c94a4f6890aa",
+                "sha256:a990acddbc0a089c8e04ef290c36050147ce99b8f234bb8b9d198a4a7651a6b0"
+            ],
+            "index": "pypi",
+            "version": "==1.2.2"
+        },
+        "urllib3": {
+            "hashes": [
+                "sha256:91056c15fa70756691db97756772bb1eb9678fa585d9184f24534b100dc60f4a",
+                "sha256:e7983572181f5e1522d9c98453462384ee92a0be7fac5f1413a1e35c56cc0461"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_version < '4'",
+            "version": "==1.25.10"
         }
     },
     "develop": {}

--- a/logging_config/Pipfile.lock
+++ b/logging_config/Pipfile.lock
@@ -58,7 +58,7 @@
                 "sha256:30639c035cdb23534cd4aa2dd52c3bf48f06e5f4a941509c8bafd8ce11080259",
                 "sha256:8b74bedcbbbaca38ff6d7491d76f2b06b3592611af620f8426e82dddb04a5ced"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2'",
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==1.15.0"
         },
         "structlog": {

--- a/logging_config/logging_set_up.py
+++ b/logging_config/logging_set_up.py
@@ -24,6 +24,7 @@ COLOR_LOGS = os.environ.get("COLOR_LOGS", False)
 LOG_LEVEL = os.environ.get("LOG_LEVEL", "DEBUG")
 INDENT = 4
 
+
 def datetime_serializer(item):
     """JSON serializer for objects not serializable by default json code"""
 

--- a/logging_config/logging_set_up.py
+++ b/logging_config/logging_set_up.py
@@ -1,12 +1,9 @@
-import io
 import json
 import logging
 import logging.config as logging_config
 import os
 from datetime import date, datetime
-from inspect import getframeinfo, stack
 
-import colorama
 from pygments import highlight
 from pygments.formatters import TerminalFormatter
 from pygments.lexers import JsonLexer

--- a/logging_config/logging_set_up.py
+++ b/logging_config/logging_set_up.py
@@ -13,6 +13,7 @@ from pygments.lexers import JsonLexer
 
 import structlog
 from structlog import processors, stdlib
+from structlog_sentry import SentryJsonProcessor
 
 #                             --=== LOGGING ===--
 
@@ -21,7 +22,7 @@ RESET_COLORS = "\032[0m"
 JSON_LOGS = os.environ.get("JSON_LOGS", True)
 COLOR_LOGS = os.environ.get("COLOR_LOGS", False)
 LOG_LEVEL = os.environ.get("LOG_LEVEL", "DEBUG")
-
+INDENT = 4
 
 def datetime_serializer(item):
     """JSON serializer for objects not serializable by default json code"""
@@ -88,9 +89,15 @@ PROCESSORS = [
 
 if JSON_LOGS:
     if COLOR_LOGS:
-        PROCESSORS += [ColoredJsonRenderer(sort_keys=True, indent=4)]
+        PROCESSORS += [
+            SentryJsonProcessor(level=logging.ERROR, tag_keys="__all__"),
+            ColoredJsonRenderer(sort_keys=True, indent=INDENT or None),
+        ]
     else:
-        PROCESSORS += [structlog.processors.JSONRenderer(sort_keys=True, indent=4)]
+        PROCESSORS += [
+            SentryJsonProcessor(level=logging.ERROR, tag_keys="__all__"),
+            structlog.processors.JSONRenderer(sort_keys=True, indent=INDENT),
+        ]
 else:
     if COLOR_LOGS:
         PROCESSORS += [colorize_json_values]


### PR DESCRIPTION
- Adds the `structlog-sentry` dependency so the formatting is right
- [From here](https://github.com/kiwicom/structlog-sentry#logging-as-json)